### PR TITLE
Use `blitz dev` instead of `blitz start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a [Blitz.js](https://github.com/blitz-js/blitz) app.
 Run your app in the development mode.
 
 ```
-blitz start
+blitz dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.


### PR DESCRIPTION
Resolves error: Could not find a production build, you must run `blitz build` before starting